### PR TITLE
Support client-cert-file/client-key-file options

### DIFF
--- a/lib/puppet/type/etcd_key.rb
+++ b/lib/puppet/type/etcd_key.rb
@@ -49,6 +49,16 @@ Puppet::Type.newtype(:etcd_key) do
     defaultto false
   end
 
+  newparam(:client_cert_file) do
+    desc "identify HTTPS client using this SSL certificate file"
+    defaultto false
+  end
+
+  newparam(:client_key_file) do
+    desc "identify HTTPS client using this SSL key file"
+    defaultto false
+  end
+
   newparam(:ca_file) do
     desc "verify certificates of HTTPS-enabled servers using this CA bundle"
     defaultto false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,11 +180,19 @@
 #
 # security
 # [*cert_file*]
-#   Path to the client server TLS cert file.
+#   Path to the server TLS cert file.  It will also be used as a client certificate if client_cert_file is empty.
 #   default: none
 #
 # [*key_file*]
-#   Path to the client server TLS key file.
+#   Path to the server TLS key file.  It will also be used as a client certificate if client_key_file is empty.
+#   default: none
+#
+# [*client_cert_file*]
+#   Path to the client TLS cert file.
+#   default: none
+#
+# [*client_key_file*]
+#   Path to the client TLS key file.
 #   default: none
 #
 # [*client_cert_auth*]
@@ -276,6 +284,8 @@ class etcd (
   # security
   $cert_file                   = $etcd::params::cert_file,
   $key_file                    = $etcd::params::key_file,
+  $client_cert_file            = $etcd::params::client_cert_file,
+  $client_key_file             = $etcd::params::client_key_file,
   $client_cert_auth            = $etcd::params::client_cert_auth,
   $trusted_ca_file             = $etcd::params::trusted_ca_file,
   $auto_tls                    = $etcd::params::auto_tls,
@@ -308,6 +318,8 @@ class etcd (
   validate_absolute_path($data_dir)
   if $cert_file { validate_absolute_path($cert_file) }
   if $key_file { validate_absolute_path($key_file) }
+  if $client_cert_file { validate_absolute_path($client_cert_file) }
+  if $client_key_file { validate_absolute_path($client_key_file) }
   if $trusted_ca_file { validate_absolute_path($trusted_ca_file) }
   if $peer_cert_file { validate_absolute_path($peer_cert_file) }
   if $peer_key_file { validate_absolute_path($peer_key_file) }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,8 @@ class etcd::params {
   # security
   $cert_file = undef
   $key_file = undef
+  $client_cert_file = undef
+  $client_key_file = undef
   $client_cert_auth = false
   $trusted_ca_file = undef
   $auto_tls = undef

--- a/templates/etc/etcd/etcd.conf.erb
+++ b/templates/etc/etcd/etcd.conf.erb
@@ -62,6 +62,12 @@ ETCD_CERT_FILE="<%= scope['etcd::cert_file'] %>"
 <% unless [nil, :undefined, :undef, ''].include?(scope['etcd::key_file']) -%>
 ETCD_KEY_FILE="<%= scope['etcd::key_file'] %>"
 <% end -%>
+<% unless [nil, :undefined, :undef, ''].include?(scope['etcd::client_cert_file']) -%>
+ETCD_CLIENT_CERT_FILE="<%= scope['etcd::client_cert_file'] %>"
+<% end -%>
+<% unless [nil, :undefined, :undef, ''].include?(scope['etcd::client_key_file']) -%>
+ETCD_CLIENT_KEY_FILE="<%= scope['etcd::client_key_file'] %>"
+<% end -%>
 ETCD_CLIENT_CERT_AUTH=<%= scope['etcd::client_cert_auth'] %>
 <% unless [nil, :undefined, :undef, ''].include?(scope['etcd::trusted_ca_file']) -%>
 ETCD_TRUSTED_CA_FILE="<%= scope['etcd::trusted_ca_file'] %>"

--- a/templates/etc/etcd/etcd.yml.erb
+++ b/templates/etc/etcd/etcd.yml.erb
@@ -128,6 +128,16 @@ client-transport-security:
   key-file: "<%= scope['etcd::key_file'] %>"
 <% end -%>
 
+<% unless [nil, :undefined, :undef, ''].include?(scope['etcd::client_cert_file']) -%>
+  # Path to the client TLS cert file.
+  client-cert-file: "<%= scope['etcd::client_cert_file'] %>"
+<% end -%>
+
+<% unless [nil, :undefined, :undef, ''].include?(scope['etcd::client_key_file']) -%>
+  # Path to the client TLS key file.
+  client-key-file: "<%= scope['etcd::client_key_file'] %>"
+<% end -%>
+
   # Enable client cert authentication.
   client-cert-auth: <%= scope['etcd::client_cert_auth'] %>
 


### PR DESCRIPTION
Since v3.5.0, `etcd` needs a client key/cert pair in some cases.

Adding support for them in form of `client-cert-file`/`client-key-file`
options in YAML config and
`ETCD_CLIENT_CERT_FILE`/`ETCD_CLIENT_KEY_FILE` env variables.